### PR TITLE
docs: add Node SDK troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,33 @@
 - 转发API无法直接向官方接口api.openai.com发起请求，需要将请求地址改为api.chatanywhere.tech才可以使用，大部分插件和软件都可以修改。
 - 遇到问题可以前往[ChatAnywhere Status](https://status.chatanywhere.tech/)查看接口可用性。
 
+### OpenAI Node.js SDK
+
+支持 OpenAI 官方 Node.js SDK。使用时需要把 `baseURL` 设置为 ChatAnywhere 的转发地址，并通过环境变量传入 API Key，避免把 Key 写进代码：
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  baseURL: process.env.OPENAI_BASE_URL || "https://api.chatanywhere.tech/v1",
+});
+
+const completion = await client.chat.completions.create({
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "Say this is a test" }],
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+如果 Node.js SDK 报 `APIConnectionError`、`fetch failed` 或 `ECONNRESET`，通常是当前运行环境到所选 Host 的网络连接被重置。请先检查 [ChatAnywhere Status](https://status.chatanywhere.tech/)，再在两个转发 Host 之间切换测试：
+
+- `https://api.chatanywhere.tech/v1`：国内首选
+- `https://api.chatanywhere.org/v1`：国外使用
+
+完整示例见 [demo/demo_nodejs.js](./demo/demo_nodejs.js)。
+
 ## 常见软件使用方法
 
 [文档-常用软件使用教程](https://chatanywhere.apifox.cn/doc-5547696)

--- a/demo/demo_nodejs.js
+++ b/demo/demo_nodejs.js
@@ -4,20 +4,30 @@ npm install openai
 
 Run:
 set OPENAI_API_KEY=your_key
+set OPENAI_BASE_URL=https://api.chatanywhere.tech/v1
 node demo/demo_nodejs.js
 */
 
 import OpenAI from "openai";
 
+const apiKey = process.env.OPENAI_API_KEY;
+const baseURL = process.env.OPENAI_BASE_URL || "https://api.chatanywhere.tech/v1";
+const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
+
+if (!apiKey) {
+  throw new Error("Please set OPENAI_API_KEY before running this demo.");
+}
+
 const client = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || "YOUR API KEY",
-  baseURL: "https://api.chatanywhere.tech/v1",
+  apiKey,
+  baseURL,
+  timeout: 60_000,
 });
 
-// Non-stream response
-async function gpt35Api(messages) {
+// Normal response
+async function chatApi(messages) {
   const completion = await client.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model,
     messages,
   });
 
@@ -25,9 +35,9 @@ async function gpt35Api(messages) {
 }
 
 // Stream response
-async function gpt35ApiStream(messages) {
+async function chatApiStream(messages) {
   const stream = await client.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model,
     messages,
     stream: true,
   });
@@ -46,9 +56,19 @@ async function gpt35ApiStream(messages) {
     { role: "user", content: "What is the relationship between Lu Xun and Zhou Shuren?" },
   ];
 
-  // Non-stream call
-  // await gpt35Api(messages);
+  try {
+    console.log(`Using ${baseURL} with model ${model}`);
 
-  // Stream call
-  await gpt35ApiStream(messages);
+    // Normal call
+    // await chatApi(messages);
+
+    // Stream call
+    await chatApiStream(messages);
+  } catch (error) {
+    console.error(error);
+    console.error(
+      "\nIf this is an APIConnectionError or ECONNRESET, verify that your runtime can access the selected ChatAnywhere host. Try switching OPENAI_BASE_URL between https://api.chatanywhere.tech/v1 and https://api.chatanywhere.org/v1, then check https://status.chatanywhere.tech/."
+    );
+    process.exitCode = 1;
+  }
 })();


### PR DESCRIPTION
## Summary
- document OpenAI Node.js SDK usage with ChatAnywhere baseURL
- make the Node demo use environment variables for API key, host, and model
- add troubleshooting guidance for APIConnectionError / ECONNRESET

Closes #425

## Test
- node --check demo/demo_nodejs.js
- git diff --check